### PR TITLE
Better emails and error messages

### DIFF
--- a/src/main/java/edu/rit/honors/gyfp/api/folder/FolderApi.java
+++ b/src/main/java/edu/rit/honors/gyfp/api/folder/FolderApi.java
@@ -332,6 +332,8 @@ public class FolderApi {
 
         String messageFormat = "<h1>Hey there, %s!</h1> \n <p><strong>%s</strong> (%s) has requested that you transfer ownership of your files on Google Drive.  "
                 + "<a href=\"https://gimmeyourfilesplease.appspot.com/#/request/%s\">Click Here</a> to reply to the request.</p>" +
+                "<p>Gimme Your Files Please (GYFP) is a new tool created by Honors Technology Committee to transition all of the Honors Program drive files to the incoming president's ownership.  We asked them to create this tool because we don't know (and aren't willing to wait and find out) what happens to files owned by a student after their RIT student email account is discontinued by IT.  Previously, we have done a more forceful transition where the entire Honors drive is downloaded and re-uploaded then re-shared with new Council and committee members, but this means that all sharing/editing/reading access and comments in documents no longer exist.</p>" +
+                "<p>If you follow the link above, log in, and then click \"Transfer Files,\" this tool will transfer ownership of any document you own in the Google drive to the requester, while you retain read/write access.</p>" +
                 "<p>Thanks!</p>" +
                 "<p><span style=\"margin-left: 50px;\"><strong>The GYFP Team</strong></span></p>";
 

--- a/src/main/webapp/js/controllers/ManageFolderController.js
+++ b/src/main/webapp/js/controllers/ManageFolderController.js
@@ -128,7 +128,7 @@ gyfp.controller("ManageFolderController", ['$scope', '$modal', '$routeParams', '
                 user.inProgress = false;
                 if(resp.error ||        resp.result.error) {
                     $scope.isErrored = true;
-                    $scope.errorMessage += $scope.errorMessage?"<br>":'' + "Failed to ask "+user.name;
+                    $scope.errorMessage += ($scope.errorMessage?"<br>":'') + "Failed to ask "+user.name;
                     user.hasActiveRequest = false;
                 }
                 console.log(resp);

--- a/src/main/webapp/js/partials/about.html
+++ b/src/main/webapp/js/partials/about.html
@@ -29,6 +29,7 @@
 <p>
     In addition to seeing the users who have access to files, {{ appName }} allows you to make bulk permission changes to the folder you opened.
     Clicking the transfer button, <a class="btn btn-primary btn-xs"><span class="glyphicon glyphicon-transfer"></span></a>,
+
     sends an email to the person you selected asking them to transfer all the files they own in the folder you opened to you.
     When they click the link in the email, they will be prompted to confirm the ownership transfer.
     Clicking the write button, <a class="btn btn-default btn-xs"><span class="glyphicon glyphicon-pencil"></span></a>,


### PR DESCRIPTION
error messages on the transfer page now work and the email has more explanation of what GYFP does, as requested by Erin Downs.

In the future, we probably want to make the email text be configurable by the user on the frontend.