### PR TITLE
Add datastore viewer pages

### DIFF
--- a/src/main/java/edu/rit/honors/gyfp/servlets/FolderViewServlet.java
+++ b/src/main/java/edu/rit/honors/gyfp/servlets/FolderViewServlet.java
@@ -1,0 +1,49 @@
+package edu.rit.honors.gyfp.servlets;
+
+import com.google.appengine.api.users.User;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import edu.rit.honors.gyfp.api.model.Folder;
+import edu.rit.honors.gyfp.util.OfyService;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Authenticates user and loads cached folders for FolderView.jsp
+ *
+ * Created by regdoug on 5/13/15.
+ */
+public class FolderViewServlet extends HttpServlet {
+
+    public static final Set<String> authorizedUsers = new HashSet<>();
+
+    static {
+        authorizedUsers.add("rdp2575@g.rit.edu");
+        authorizedUsers.add("gjd6793@g.rit.edu");
+    }
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        UserService userService = UserServiceFactory.getUserService();
+        User user = userService.getCurrentUser();
+        req.setAttribute("user", user);
+        if(null == user) {
+            req.setAttribute("loginurl",userService.createLoginURL(req.getRequestURI()));
+        } else {
+            req.setAttribute("logouturl", userService.createLogoutURL(req.getRequestURI()));
+            boolean validUser = authorizedUsers.contains(user.getEmail());
+            req.setAttribute("validuser", validUser);
+            if (validUser) {
+                List<Folder> folders = OfyService.ofy().load().type(Folder.class).list();
+                req.setAttribute("folders", folders);
+            }
+        }
+        req.getRequestDispatcher("/FolderView.jsp").forward(req,resp);
+    }
+}

--- a/src/main/java/edu/rit/honors/gyfp/servlets/TransferRequestViewServlet.java
+++ b/src/main/java/edu/rit/honors/gyfp/servlets/TransferRequestViewServlet.java
@@ -1,0 +1,49 @@
+package edu.rit.honors.gyfp.servlets;
+
+import com.google.appengine.api.users.User;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import edu.rit.honors.gyfp.api.model.TransferRequest;
+import edu.rit.honors.gyfp.util.OfyService;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Authenticates user and loads transfer requests for TransferRequestView.jsp
+ *
+ * Created by regdoug on 5/13/15.
+ */
+public class TransferRequestViewServlet extends HttpServlet {
+
+    public static final Set<String> authorizedUsers = new HashSet<>();
+
+    static {
+        authorizedUsers.add("rdp2575@g.rit.edu");
+        authorizedUsers.add("gjd6793@g.rit.edu");
+    }
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        UserService userService = UserServiceFactory.getUserService();
+        User user = userService.getCurrentUser();
+        req.setAttribute("user",user);
+        if(null == user) {
+            req.setAttribute("loginURL", userService.createLoginURL(req.getRequestURI()));
+        } else {
+            req.setAttribute("logoutURL",userService.createLogoutURL(req.getRequestURI()));
+            boolean validUser = true || authorizedUsers.contains(user.getEmail());
+            req.setAttribute("validuser", validUser);
+            if (validUser) {
+                List<TransferRequest> transferRequests = OfyService.ofy().load().type(TransferRequest.class).list();
+                req.setAttribute("trlist", transferRequests);
+            }
+        }
+        req.getRequestDispatcher("/TransferRequestView.jsp").forward(req,resp);
+    }
+}

--- a/src/main/webapp/FolderView.jsp
+++ b/src/main/webapp/FolderView.jsp
@@ -1,0 +1,120 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ page import="com.google.appengine.api.users.User" %>
+<%@ page import="edu.rit.honors.gyfp.api.model.Folder" %>
+<%@ page import="java.util.List" %>
+<%--
+  Created by IntelliJ IDEA.
+  User: regdoug
+  Date: 5/13/15
+  Time: 4:36 PM
+
+  Displays cached folder ids.  Backend is edu.rit.honors.gyfp.servlets.FolderViewServlet
+--%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Cached Folders | Gimme Your Files Please</title>
+
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootswatch/3.2.0/cyborg/bootstrap.min.css" />
+    <link rel="stylesheet" href="css/base.css" />
+
+    <link rel="apple-touch-icon" sizes="57x57" href="<c:url value="/img/apple-icon-57x57.png"/>">
+    <link rel="apple-touch-icon" sizes="60x60" href="<c:url value="/img/apple-icon-60x60.png"/>">
+    <link rel="apple-touch-icon" sizes="72x72" href="<c:url value="/img/apple-icon-72x72.png"/>">
+    <link rel="apple-touch-icon" sizes="76x76" href="<c:url value="/img/apple-icon-76x76.png"/>">
+    <link rel="apple-touch-icon" sizes="114x114" href="<c:url value="/img/apple-icon-114x114.png"/>">
+    <link rel="apple-touch-icon" sizes="120x120" href="<c:url value="/img/apple-icon-120x120.png"/>">
+    <link rel="apple-touch-icon" sizes="144x144" href="<c:url value="/img/apple-icon-144x144.png"/>">
+    <link rel="apple-touch-icon" sizes="152x152" href="<c:url value="/img/apple-icon-152x152.png"/>">
+    <link rel="apple-touch-icon" sizes="180x180" href="<c:url value="/img/apple-icon-180x180.png"/>">
+    <link rel="icon" type="image/png" sizes="192x192"  href="<c:url value="/img/android-icon-192x192.png"/>">
+    <link rel="icon" type="image/png" sizes="32x32" href="<c:url value="/img/favicon-32x32.png"/>">
+    <link rel="icon" type="image/png" sizes="96x96" href="<c:url value="/img/favicon-96x96.png"/>">
+    <link rel="icon" type="image/png" sizes="16x16" href="<c:url value="/img/favicon-16x16.png"/>">
+    <link rel="manifest" href="<c:url value="/img/manifest.json"/>">
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="msapplication-TileImage" content="<c:url value="/img/ms-icon-144x144.png"/>">
+    <meta name="theme-color" content="#ffffff">
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <script type="application/javascript" src="js/third-party/angular/ui-utils/ui-utils-ieshiv.js"></script>
+    <![endif]-->
+</head>
+<body>
+<div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+    <div class="container">
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target=".navbar-collapse">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+
+            <img src="<c:url value="/img/android-icon-48x48.png"/>" alt="Gimme Your Files, Please Logo" class="logo" />
+            <a class="navbar-brand" href="#">
+                Gimme Your Files, Please!
+            </a>
+        </div>
+        <div class="collapse navbar-collapse">
+            <ul class="nav navbar-nav">
+                <li><a href="/#/about">About</a></li>
+            </ul>
+
+            <div class="pull-right auth-container">
+                <c:choose>
+                    <c:when test="${user ne null}">
+                        <span>${user.email}</span>
+                        <a href="${logouturl}" class="btn btn-primary" type="button">
+                            Log Out
+                        </a>
+                    </c:when>
+                    <c:otherwise>
+                        <a href="${loginurl}" class="btn btn-primary" type="button">
+                            Log In
+                        </a>
+                    </c:otherwise>
+                </c:choose>
+            </div>
+        </div>
+        <!--/.nav-collapse -->
+    </div>
+</div>
+
+<div id="main" class="container">
+<c:choose>
+<c:when test="${validuser}">
+    <h1>Cached Folders</h1>
+    <table class="table">
+        <thead>
+        <tr><th>Folder ID</th><th>Owner</th></tr>
+        </thead>
+        <tbody>
+        <c:forEach items="${folders}" var="f">
+            <tr>
+                <td>${f.id}</td>
+                <td>${f.ownerUserId}</td>
+            </tr>
+        </c:forEach>
+        </tbody>
+    </table>
+</c:when>
+<c:otherwise>
+    <h1>Not Authorized</h1>
+    <p>You are not an authorized user. If you think this is a mistake, contact technology@honors.rit.edu</p>
+</c:otherwise>
+</c:choose>
+</div>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" type="application/javascript"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js" type="application/javascript"></script>
+</body>
+</html>

--- a/src/main/webapp/TransferRequestView.jsp
+++ b/src/main/webapp/TransferRequestView.jsp
@@ -1,0 +1,121 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ page import="com.google.appengine.api.users.User" %>
+<%@ page import="edu.rit.honors.gyfp.api.model.TransferRequest" %>
+<%@ page import="java.util.List" %>
+<%--
+  Created by IntelliJ IDEA.
+  User: regdoug
+  Date: 5/13/15
+  Time: 4:36 PM
+
+  Displays outstanding transfer requests.  Backend is edu.rit.honors.gyfp.servlets.TransferRequestViewServlet
+--%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Transfer Requests Outstanding | Gimme Your Files Please</title>
+
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootswatch/3.2.0/cyborg/bootstrap.min.css" />
+    <link rel="stylesheet" href="css/base.css" />
+
+    <link rel="apple-touch-icon" sizes="57x57" href="<c:url value="/img/apple-icon-57x57.png"/>">
+    <link rel="apple-touch-icon" sizes="60x60" href="<c:url value="/img/apple-icon-60x60.png"/>">
+    <link rel="apple-touch-icon" sizes="72x72" href="<c:url value="/img/apple-icon-72x72.png"/>">
+    <link rel="apple-touch-icon" sizes="76x76" href="<c:url value="/img/apple-icon-76x76.png"/>">
+    <link rel="apple-touch-icon" sizes="114x114" href="<c:url value="/img/apple-icon-114x114.png"/>">
+    <link rel="apple-touch-icon" sizes="120x120" href="<c:url value="/img/apple-icon-120x120.png"/>">
+    <link rel="apple-touch-icon" sizes="144x144" href="<c:url value="/img/apple-icon-144x144.png"/>">
+    <link rel="apple-touch-icon" sizes="152x152" href="<c:url value="/img/apple-icon-152x152.png"/>">
+    <link rel="apple-touch-icon" sizes="180x180" href="<c:url value="/img/apple-icon-180x180.png"/>">
+    <link rel="icon" type="image/png" sizes="192x192"  href="<c:url value="/img/android-icon-192x192.png"/>">
+    <link rel="icon" type="image/png" sizes="32x32" href="<c:url value="/img/favicon-32x32.png"/>">
+    <link rel="icon" type="image/png" sizes="96x96" href="<c:url value="/img/favicon-96x96.png"/>">
+    <link rel="icon" type="image/png" sizes="16x16" href="<c:url value="/img/favicon-16x16.png"/>">
+    <link rel="manifest" href="<c:url value="/img/manifest.json"/>">
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="msapplication-TileImage" content="<c:url value="/img/ms-icon-144x144.png"/>">
+    <meta name="theme-color" content="#ffffff">
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <script type="application/javascript" src="js/third-party/angular/ui-utils/ui-utils-ieshiv.js"></script>
+    <![endif]-->
+</head>
+<body>
+<div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+    <div class="container">
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target=".navbar-collapse">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+
+            <img src="<c:url value="/img/android-icon-48x48.png"/>" alt="Gimme Your Files, Please Logo" class="logo" />
+            <a class="navbar-brand" href="#">
+                Gimme Your Files, Please!
+            </a>
+        </div>
+        <div class="collapse navbar-collapse">
+            <ul class="nav navbar-nav">
+                <li><a href="/#/about">About</a></li>
+            </ul>
+
+            <div class="pull-right auth-container">
+                <c:choose>
+                <c:when test="${user ne null}">
+                    <span>${user.email}</span>
+                    <a href="${logoutURL}" class="btn btn-primary" type="button">
+                        Log Out
+                    </a>
+                </c:when>
+                <c:otherwise>
+                    <a href="${loginURL}" class="btn btn-primary" type="button">
+                        Log In
+                    </a>
+                </c:otherwise>
+                </c:choose>
+            </div>
+        </div>
+        <!--/.nav-collapse -->
+    </div>
+</div>
+
+<div id="main" class="container">
+<c:choose>
+<c:when test="${validuser}">
+    <h1>Transfer Requests</h1>
+    <table class="table">
+        <thead>
+        <tr><th>Transfer Request ID</th><th>Requester</th><th>Recipient</th></tr>
+        </thead>
+        <tbody>
+        <c:forEach items="${trlist}" var="tr">
+            <tr>
+                <td>${tr.id}</td>
+                <td>${tr.requestingUser.name} (${tr.requestingUser.email})</td>
+                <td>${tr.targetUser.name} (${tr.targetUser.email}</td>
+            </tr>
+        </c:forEach>
+        </tbody>
+    </table>
+</c:when>
+<c:otherwise>
+    <h1>Not Authorized</h1>
+    <p>You are not an authorized user. If you think this is a mistake, contact technology@honors.rit.edu</p>
+</c:otherwise>
+</c:choose>
+</div>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" type="application/javascript"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js" type="application/javascript"></script>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
     <application>gimmeyourfilesplease</application>
-    <version>release1</version>
+    <version>cacheview</version>
     <threadsafe>true</threadsafe>
     
     <system-properties>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -14,6 +14,18 @@
         <servlet-name>DriveOpenRedirectServlet</servlet-name>
         <servlet-class>edu.rit.honors.gyfp.servlets.DriveOpenRedirectServlet</servlet-class>
     </servlet>
+    <servlet>
+        <servlet-name>appstats</servlet-name>
+        <servlet-class>com.google.appengine.tools.appstats.AppstatsServlet</servlet-class>
+    </servlet>
+    <servlet>
+        <servlet-name>trview</servlet-name>
+        <servlet-class>edu.rit.honors.gyfp.servlets.TransferRequestViewServlet</servlet-class>
+    </servlet>
+    <servlet>
+        <servlet-name>folderview</servlet-name>
+        <servlet-class>edu.rit.honors.gyfp.servlets.FolderViewServlet</servlet-class>
+    </servlet>
 
     <servlet-mapping>
         <servlet-name>Oauth2Callback</servlet-name>
@@ -26,6 +38,18 @@
     <servlet-mapping>
         <servlet-name>DriveOpenRedirectServlet</servlet-name>
         <url-pattern>/open</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>appstats</servlet-name>
+        <url-pattern>/appstats/*</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>trview</servlet-name>
+        <url-pattern>/cache/transferrequest</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>folderview</servlet-name>
+        <url-pattern>/cache/folder</url-pattern>
     </servlet-mapping>
 
     <security-constraint>
@@ -85,15 +109,6 @@
     </filter-mapping>
 
 
-    <servlet>
-        <servlet-name>appstats</servlet-name>
-        <servlet-class>com.google.appengine.tools.appstats.AppstatsServlet</servlet-class>
-    </servlet>
-
-    <servlet-mapping>
-        <servlet-name>appstats</servlet-name>
-        <url-pattern>/appstats/*</url-pattern>
-    </servlet-mapping>
 
     <security-constraint>
         <web-resource-collection>


### PR DESCRIPTION
going to /cache/folder and cache/transferrequest display the folders and transfer
requests, respectively, that are stored in the datastore.

Authentication is simply hardcoded to Reggie and Greg.

**Note**: This has a appengine version of `cacheview`. This code is deployed there right now and works.  If this is merged into master, the version should probably be changed and/or the default appengine version should be changed.
